### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
-## [1.2.0]
+## [1.2.0] - [PR #27](https://github.com/MeteoraAg/zap-sdk/pull/27)
 
 ### Added
 
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Changed
 
 - Replace `lite-api.jup.ag` with `api.jup.ag` as the default Jupiter API endpoint
-- Add optional `jupiterApiUrl` and `jupiterApiKey` parameters to `Zap` class constructor and all Jupiter-related helper functions (`getJupiterQuote`, `getJupiterSwapInstruction`, `buildJupiterSwapTransaction`, `getJupAndDammV2Quotes`, `estimateDlmmIndirectSwap`, `estimateDlmmDirectSwap`, `estimateDlmmRebalanceSwap`) for explicit API configuration
+- Add optional `config.jupiterApiUrl` and `config.jupiterApiKey` parameters to `Zap` class constructor and all Jupiter-related helper functions (`getJupiterQuote`, `getJupiterSwapInstruction`, `buildJupiterSwapTransaction`, `getJupAndDammV2Quotes`, `estimateDlmmIndirectSwap`, `estimateDlmmDirectSwap`, `estimateDlmmRebalanceSwap`) for explicit API configuration
 
 ## [1.1.2] - [PR #26](https://github.com/MeteoraAg/zap-sdk/pull/26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
+## [1.2.0]
+
+### Added
+
+- Jupiter API Setup section in README with instructions for obtaining API keys and configuring the SDK
+
+### Changed
+
+- Replace `lite-api.jup.ag` with `api.jup.ag` as the default Jupiter API endpoint
+- Add optional `jupiterApiUrl` and `jupiterApiKey` parameters to `Zap` class constructor and all Jupiter-related helper functions (`getJupiterQuote`, `getJupiterSwapInstruction`, `buildJupiterSwapTransaction`, `getJupAndDammV2Quotes`, `estimateDlmmIndirectSwap`, `estimateDlmmDirectSwap`, `estimateDlmmRebalanceSwap`) for explicit API configuration
+
 ## [1.1.2] - [PR #26](https://github.com/MeteoraAg/zap-sdk/pull/26)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ pnpm install @meteora-ag/zap-sdk
 yarn add @meteora-ag/zap-sdk
 ```
 
+## Jupiter API Setup
+
+All Jupiter-related functions (`getJupiterQuote`, `getJupiterSwapInstruction`, and estimate functions) support custom API configuration.
+
+### Getting Your Jupiter API Key
+
+As of January 31st 2026, Jupiter requires an API key for all api request to https://api.jup.ag/. Obtain your API key at the [Jupiter Portal](https://portal.jup.ag/)
+
+For detailed setup instructions, see [Jupiter's Setup Guide](https://dev.jup.ag/portal/setup).
+
+### API Parameters
+
+All Jupiter functions accept optional `jupiterApiUrl` and `jupiterApiKey` parameters:
+
+- `jupiterApiUrl` (optional): The Jupiter API endpoint. Default: `"https://api.jup.ag"`
+- `jupiterApiKey` (optional): Your Jupiter API key. Default: `""` (empty string)
+
+**Note**: While the API key parameter is optional in the function signature, Jupiter requires an API key for all requests. Using the default empty string may result in API errors.
+
 ## Initialization
 
 ```typescript
@@ -23,7 +42,10 @@ import { Connection } from "@solana/web3.js";
 import { Zap } from "@meteora-ag/zap-sdk";
 
 const connection = new Connection("https://api.mainnet-beta.solana.com");
-const zap = new Zap(connection);
+const jupiterApiUrl = "https://api.jup.ag";
+const jupiterApiKey = "YOUR_API_KEY_HERE";
+
+const zap = new Zap(connection, jupiterApiUrl, jupiterApiKey);
 ```
 
 ## Usage

--- a/docs.md
+++ b/docs.md
@@ -128,15 +128,19 @@ const quoteResponse = await getJupiterQuote(
   false,
   true,
   true,
-  "https://api.jup.ag",
-  "YOUR_JUPITER_API_KEY"
+  {
+    jupiterApiUrl: "https://api.jup.ag",
+    jupiterApiKey: "YOUR_JUPITER_API_KEY"
+  }
 );
 
 const swapInstructionResponse = await getJupiterSwapInstruction(
   wallet.publicKey,
   quoteResponse,
-  "https://api.jup.ag",
-  "YOUR_JUPITER_API_KEY"
+  {
+    jupiterApiUrl: "https://api.jup.ag",
+    jupiterApiKey: "YOUR_JUPITER_API_KEY"
+  }
 );
 
 const inputMint = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
@@ -343,8 +347,7 @@ async getJupiterQuote(
   dynamicSlippage: boolean = false,
   onlyDirectRoutes: boolean,
   restrictIntermediateTokens: boolean,
-  jupiterApiUrl: string = "https://api.jup.ag",
-  jupiterApiKey: string = ""
+  config: ZapConfig = {}
 ): Promise<JupiterQuoteResponse | null>
 ```
 
@@ -360,8 +363,12 @@ interface GetJupiterQuoteParams {
   dynamicSlippage: boolean;
   onlyDirectRoutes: boolean;
   restrictIntermediateTokens: boolean;
-  jupiterApiUrl: string;
-  jupiterApiKey: string;
+  config?: ZapConfig; // Optional config object containing jupiterApiUrl and jupiterApiKey
+}
+
+interface ZapConfig {
+  jupiterApiUrl?: string; // Default: "https://api.jup.ag"
+  jupiterApiKey?: string; // Default: ""
 }
 ```
 
@@ -381,8 +388,10 @@ const quoteResponse = await getJupiterQuote(
   false,
   true,
   true,
-  "https://api.jup.ag",
-  "YOUR_JUPITER_API_KEY"
+  {
+    jupiterApiUrl: "https://api.jup.ag",
+    jupiterApiKey: "YOUR_JUPITER_API_KEY"
+  }
 );
 ```
 
@@ -403,8 +412,7 @@ Get Jupiter swap instruction from Jupiter API.
 async getJupiterSwapInstruction(
   userPublicKey: PublicKey,
   quoteResponse: any,
-  jupiterApiUrl: string = "https://api.jup.ag",
-  jupiterApiKey: string = ""
+  config: ZapConfig = {}
 ): Promise<JupiterSwapInstructionResponse>
 ```
 
@@ -414,8 +422,12 @@ async getJupiterSwapInstruction(
 interface GetJupiterSwapInstructionParams {
   userPublicKey: PublicKey;
   quoteResponse: any;
-  jupiterApiUrl: string;
-  jupiterApiKey: string;
+  config?: ZapConfig; // Optional config object containing jupiterApiUrl and jupiterApiKey
+}
+
+interface ZapConfig {
+  jupiterApiUrl?: string; // Default: "https://api.jup.ag"
+  jupiterApiKey?: string; // Default: ""
 }
 ```
 
@@ -435,15 +447,19 @@ const quoteResponse = await getJupiterQuote(
   false,
   true,
   true,
-  "https://api.jup.ag",
-  "YOUR_JUPITER_API_KEY"
+  {
+    jupiterApiUrl: "https://api.jup.ag",
+    jupiterApiKey: "YOUR_JUPITER_API_KEY"
+  }
 );
 
 const swapInstructionResponse = await getJupiterSwapInstruction(
   wallet.publicKey,
   quoteResponse,
-  "https://api.jup.ag",
-  "YOUR_JUPITER_API_KEY"
+  {
+    jupiterApiUrl: "https://api.jup.ag",
+    jupiterApiKey: "YOUR_JUPITER_API_KEY"
+  }
 );
 ```
 

--- a/docs.md
+++ b/docs.md
@@ -125,15 +125,18 @@ const quoteResponse = await getJupiterQuote(
   swapAmount,
   40,
   50,
+  false,
   true,
   true,
-  true,
-  "https://lite-api.jup.ag"
+  "https://api.jup.ag",
+  "YOUR_JUPITER_API_KEY"
 );
 
 const swapInstructionResponse = await getJupiterSwapInstruction(
   wallet.publicKey,
-  quoteResponse
+  quoteResponse,
+  "https://api.jup.ag",
+  "YOUR_JUPITER_API_KEY"
 );
 
 const inputMint = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
@@ -340,9 +343,9 @@ async getJupiterQuote(
   dynamicSlippage: boolean = false,
   onlyDirectRoutes: boolean,
   restrictIntermediateTokens: boolean,
-  apiUrl: string = "https://lite-api.jup.ag",
-  apiKey?: string
-): Promise<JupiterQuoteResponse>
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
+): Promise<JupiterQuoteResponse | null>
 ```
 
 #### Parameters
@@ -354,11 +357,11 @@ interface GetJupiterQuoteParams {
   amount: BN;
   maxAccounts: number;
   slippageBps: number;
-  dynamicSlippage: boolean = false;
+  dynamicSlippage: boolean;
   onlyDirectRoutes: boolean;
   restrictIntermediateTokens: boolean;
-  apiUrl: string = "https://lite-api.jup.ag";
-  apiKey?: string;
+  jupiterApiUrl: string;
+  jupiterApiKey: string;
 }
 ```
 
@@ -375,10 +378,11 @@ const quoteResponse = await getJupiterQuote(
   new BN(1000000000),
   40,
   50,
+  false,
   true,
   true,
-  true,
-  "https://lite-api.jup.ag"
+  "https://api.jup.ag",
+  "YOUR_JUPITER_API_KEY"
 );
 ```
 
@@ -398,9 +402,9 @@ Get Jupiter swap instruction from Jupiter API.
 ```typescript
 async getJupiterSwapInstruction(
   userPublicKey: PublicKey,
-  quoteResponse: JupiterQuoteResponse,
-  apiUrl: string = "https://lite-api.jup.ag",
-  apiKey?: string
+  quoteResponse: any,
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
 ): Promise<JupiterSwapInstructionResponse>
 ```
 
@@ -408,10 +412,10 @@ async getJupiterSwapInstruction(
 
 ```typescript
 interface GetJupiterSwapInstructionParams {
-  inputMint: PublicKey;
-  quoteResponse: JupiterQuoteResponse;
-  apiUrl: string = "https://lite-api.jup.ag";
-  apiKey?: string;
+  userPublicKey: PublicKey;
+  quoteResponse: any;
+  jupiterApiUrl: string;
+  jupiterApiKey: string;
 }
 ```
 
@@ -428,16 +432,18 @@ const quoteResponse = await getJupiterQuote(
   new BN(1000000000),
   40,
   50,
+  false,
   true,
   true,
-  true,
-  "https://lite-api.jup.ag"
+  "https://api.jup.ag",
+  "YOUR_JUPITER_API_KEY"
 );
 
 const swapInstructionResponse = await getJupiterSwapInstruction(
   wallet.publicKey,
-  quoteResponse
-  apiUrl: "https://lite-api.jup.ag",
+  quoteResponse,
+  "https://api.jup.ag",
+  "YOUR_JUPITER_API_KEY"
 );
 ```
 

--- a/examples/constants.ts
+++ b/examples/constants.ts
@@ -1,0 +1,3 @@
+export const JUPITER_API_URL =
+  process.env.JUPITER_API_URL || "https://api.jup.ag";
+export const JUPITER_API_KEY = process.env.JUPITER_API_KEY || "";

--- a/examples/constants.ts
+++ b/examples/constants.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_JUPITER_API_URL } from "../src";
+
 export const JUPITER_API_URL =
-  process.env.JUPITER_API_URL || "https://api.jup.ag";
+  process.env.JUPITER_API_URL || DEFAULT_JUPITER_API_URL;
 export const JUPITER_API_KEY = process.env.JUPITER_API_KEY || "";

--- a/examples/rebalanceDlmmPosition.ts
+++ b/examples/rebalanceDlmmPosition.ts
@@ -62,7 +62,10 @@ async function main() {
 
   const positionAddress = new PublicKey("YOUR POSITION ADDRESS");
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const estimate = await estimateDlmmRebalanceSwap({
     lbPair: dlmmPool,
@@ -72,8 +75,10 @@ async function main() {
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
-    jupiterApiUrl: JUPITER_API_URL,
-    jupiterApiKey: JUPITER_API_KEY,
+    config: {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    },
   });
 
   const result = await zap.rebalanceDlmmPosition({

--- a/examples/rebalanceDlmmPosition.ts
+++ b/examples/rebalanceDlmmPosition.ts
@@ -5,6 +5,7 @@ import { estimateDlmmRebalanceSwap, Zap } from "../src";
 import Decimal from "decimal.js";
 import BN from "bn.js";
 import { createJitoTipIx, getKeypairFromSeed, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const JITO_PRIVATE_KEY = process.env.JITO_PRIVATE_KEY!;
 
@@ -61,7 +62,7 @@ async function main() {
 
   const positionAddress = new PublicKey("YOUR POSITION ADDRESS");
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const estimate = await estimateDlmmRebalanceSwap({
     lbPair: dlmmPool,
@@ -71,6 +72,8 @@ async function main() {
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
   });
 
   const result = await zap.rebalanceDlmmPosition({

--- a/examples/removeDammV2LiquidityAndZapOut.ts
+++ b/examples/removeDammV2LiquidityAndZapOut.ts
@@ -17,6 +17,7 @@ import {
   Rounding,
 } from "@meteora-ag/cp-amm-sdk";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { JUPITER_API_URL, JUPITER_API_KEY } from "./constants";
 
 async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com");
@@ -35,7 +36,7 @@ async function main() {
     "7ccKzmrXBpFHwyZGPqPuKL6bEyWAETSnHwnWe3jEneVc"
   );
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
   const cpAmm = new CpAmm(connection);
 
   try {
@@ -136,7 +137,8 @@ async function main() {
         false,
         true,
         true,
-        "https://lite-api.jup.ag"
+        JUPITER_API_URL,
+        JUPITER_API_KEY
       ),
     ]);
 
@@ -208,7 +210,9 @@ async function main() {
     } else if (bestProtocol === "jupiter" && quotes.jupiter) {
       const swapInstructionResponse = await getJupiterSwapInstruction(
         wallet.publicKey,
-        quotes.jupiter
+        quotes.jupiter,
+        JUPITER_API_URL,
+        JUPITER_API_KEY
       );
 
       zapOutTx = await zap.zapOutThroughJupiter({

--- a/examples/removeDammV2LiquidityAndZapOut.ts
+++ b/examples/removeDammV2LiquidityAndZapOut.ts
@@ -36,7 +36,10 @@ async function main() {
     "7ccKzmrXBpFHwyZGPqPuKL6bEyWAETSnHwnWe3jEneVc"
   );
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
   const cpAmm = new CpAmm(connection);
 
   try {
@@ -137,8 +140,10 @@ async function main() {
         false,
         true,
         true,
-        JUPITER_API_URL,
-        JUPITER_API_KEY
+        {
+          jupiterApiUrl: JUPITER_API_URL,
+          jupiterApiKey: JUPITER_API_KEY,
+        }
       ),
     ]);
 
@@ -211,8 +216,10 @@ async function main() {
       const swapInstructionResponse = await getJupiterSwapInstruction(
         wallet.publicKey,
         quotes.jupiter,
-        JUPITER_API_URL,
-        JUPITER_API_KEY
+        {
+          jupiterApiUrl: JUPITER_API_URL,
+          jupiterApiKey: JUPITER_API_KEY,
+        }
       );
 
       zapOutTx = await zap.zapOutThroughJupiter({

--- a/examples/removeDlmmLiquidityAndZapOut.ts
+++ b/examples/removeDlmmLiquidityAndZapOut.ts
@@ -11,6 +11,7 @@ import { getJupiterQuote, getJupiterSwapInstruction } from "../src/helpers";
 import DLMM, { getTokenProgramId } from "@meteora-ag/dlmm";
 import { DLMM_PROGRAM_ID } from "../src";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com");
@@ -29,7 +30,7 @@ async function main() {
     "9NRifL3nKQU84hMTbhE7spakkGy5vq4AvNHNQYr8LkW7"
   );
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
   const dlmm = await DLMM.create(connection, lbPairAddress, {
     cluster: "mainnet-beta",
     programId: new PublicKey(DLMM_PROGRAM_ID),
@@ -124,7 +125,8 @@ async function main() {
         false,
         true,
         true,
-        "https://lite-api.jup.ag"
+        JUPITER_API_URL,
+        JUPITER_API_KEY
       ),
     ]);
 
@@ -196,7 +198,9 @@ async function main() {
     } else if (bestProtocol === "jupiter" && quotes.jupiter) {
       const swapInstructionResponse = await getJupiterSwapInstruction(
         wallet.publicKey,
-        quotes.jupiter
+        quotes.jupiter,
+        JUPITER_API_URL,
+        JUPITER_API_KEY
       );
 
       zapOutTx = await zap.zapOutThroughJupiter({

--- a/examples/removeDlmmLiquidityAndZapOut.ts
+++ b/examples/removeDlmmLiquidityAndZapOut.ts
@@ -30,7 +30,10 @@ async function main() {
     "9NRifL3nKQU84hMTbhE7spakkGy5vq4AvNHNQYr8LkW7"
   );
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
   const dlmm = await DLMM.create(connection, lbPairAddress, {
     cluster: "mainnet-beta",
     programId: new PublicKey(DLMM_PROGRAM_ID),
@@ -125,8 +128,10 @@ async function main() {
         false,
         true,
         true,
-        JUPITER_API_URL,
-        JUPITER_API_KEY
+        {
+          jupiterApiUrl: JUPITER_API_URL,
+          jupiterApiKey: JUPITER_API_KEY,
+        }
       ),
     ]);
 
@@ -199,8 +204,10 @@ async function main() {
       const swapInstructionResponse = await getJupiterSwapInstruction(
         wallet.publicKey,
         quotes.jupiter,
-        JUPITER_API_URL,
-        JUPITER_API_KEY
+        {
+          jupiterApiUrl: JUPITER_API_URL,
+          jupiterApiKey: JUPITER_API_KEY,
+        }
       );
 
       zapOutTx = await zap.zapOutThroughJupiter({

--- a/examples/zapInDammV2DirectPool.ts
+++ b/examples/zapInDammV2DirectPool.ts
@@ -56,7 +56,10 @@ async function main() {
   const usdcDecimal = 6; // USDC has 6 decimals
   const amountUseToAddLiquidity = new BN(5 * 10 ** usdcDecimal); // 5 USDC
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const { tokenAMint, tokenBMint } = poolState;
 
@@ -81,8 +84,10 @@ async function main() {
     300, //dammV2SlippageBps: 300,
     300, // jup slippageBps:
     40, // maxAccounts
-    JUPITER_API_URL,
-    JUPITER_API_KEY
+    {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    }
   );
 
   const result = await zap.getZapInDammV2DirectPoolParams({

--- a/examples/zapInDammV2DirectPool.ts
+++ b/examples/zapInDammV2DirectPool.ts
@@ -12,6 +12,7 @@ import { getJupAndDammV2Quotes } from "../src/helpers/zapin";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { createJitoTipIx, sendJitoBundle } from "./helpers";
 import BN from "bn.js";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const MAINNET_RPC_URL = "";
 
@@ -55,7 +56,7 @@ async function main() {
   const usdcDecimal = 6; // USDC has 6 decimals
   const amountUseToAddLiquidity = new BN(5 * 10 ** usdcDecimal); // 5 USDC
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const { tokenAMint, tokenBMint } = poolState;
 
@@ -79,7 +80,9 @@ async function main() {
     tokenBDecimal,
     300, //dammV2SlippageBps: 300,
     300, // jup slippageBps:
-    40 // maxAccounts
+    40, // maxAccounts
+    JUPITER_API_URL,
+    JUPITER_API_KEY
   );
 
   const result = await zap.getZapInDammV2DirectPoolParams({

--- a/examples/zapInDammV2IndirectPool.ts
+++ b/examples/zapInDammV2IndirectPool.ts
@@ -59,7 +59,10 @@ const keypairPath = "";
   const usdcDecimal = 6; // USDC has 6 decimals
   const amountUseToAddLiquidity = new BN(5 * 10 ** usdcDecimal); // 5 USDC
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const jupiterQuoteToA = await getJupiterQuote(
     NATIVE_MINT,
@@ -70,8 +73,10 @@ const keypairPath = "";
     false,
     true,
     true,
-    JUPITER_API_URL,
-    JUPITER_API_KEY
+    {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    }
   );
 
   const jupiterQuoteToB = await getJupiterQuote(
@@ -83,8 +88,10 @@ const keypairPath = "";
     false,
     true,
     true,
-    JUPITER_API_URL,
-    JUPITER_API_KEY
+    {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    }
   );
 
   const result = await zap.getZapInDammV2IndirectPoolParams({

--- a/examples/zapInDammV2IndirectPool.ts
+++ b/examples/zapInDammV2IndirectPool.ts
@@ -15,6 +15,7 @@ import Decimal from "decimal.js";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 import { createJitoTipIx, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const MAINNET_RPC_URL = "";
 
@@ -58,7 +59,7 @@ const keypairPath = "";
   const usdcDecimal = 6; // USDC has 6 decimals
   const amountUseToAddLiquidity = new BN(5 * 10 ** usdcDecimal); // 5 USDC
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const jupiterQuoteToA = await getJupiterQuote(
     NATIVE_MINT,
@@ -69,7 +70,8 @@ const keypairPath = "";
     false,
     true,
     true,
-    "https://lite-api.jup.ag"
+    JUPITER_API_URL,
+    JUPITER_API_KEY
   );
 
   const jupiterQuoteToB = await getJupiterQuote(
@@ -81,7 +83,8 @@ const keypairPath = "";
     false,
     true,
     true,
-    "https://lite-api.jup.ag"
+    JUPITER_API_URL,
+    JUPITER_API_KEY
   );
 
   const result = await zap.getZapInDammV2IndirectPoolParams({

--- a/examples/zapInDlmmDirect.ts
+++ b/examples/zapInDlmmDirect.ts
@@ -32,7 +32,10 @@ async function main() {
   );
   const amountUseToAddLiquidity = new BN(100 * 10 ** 6); // 100 PUMP
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
   const estimate = await estimateDlmmDirectSwap({
@@ -44,8 +47,10 @@ async function main() {
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
-    jupiterApiUrl: JUPITER_API_URL,
-    jupiterApiKey: JUPITER_API_KEY,
+    config: {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    },
   });
 
   const result = await zap.getZapInDlmmDirectParams({

--- a/examples/zapInDlmmDirect.ts
+++ b/examples/zapInDlmmDirect.ts
@@ -11,6 +11,7 @@ import Decimal from "decimal.js";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 import { createJitoTipIx, getKeypairFromSeed, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const JITO_PRIVATE_KEY = process.env.JITO_PRIVATE_KEY!;
 
@@ -31,7 +32,7 @@ async function main() {
   );
   const amountUseToAddLiquidity = new BN(100 * 10 ** 6); // 100 PUMP
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
   const estimate = await estimateDlmmDirectSwap({
@@ -43,6 +44,8 @@ async function main() {
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
   });
 
   const result = await zap.getZapInDlmmDirectParams({

--- a/examples/zapInDlmmDirectSingleSided.ts
+++ b/examples/zapInDlmmDirectSingleSided.ts
@@ -31,7 +31,10 @@ async function main() {
   );
   const amountUseToAddLiquidity = new BN(100 * 10 ** 6); // 100 PUMP
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 68;
   const isInputTokenX = inputTokenMint.equals(dlmm.lbPair.tokenXMint);
@@ -52,8 +55,10 @@ async function main() {
     maxDeltaId,
     strategy: StrategyType.Spot,
     singleSided,
-    jupiterApiUrl: JUPITER_API_URL,
-    jupiterApiKey: JUPITER_API_KEY,
+    config: {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    },
   });
 
   const result = await zap.getZapInDlmmDirectParams({

--- a/examples/zapInDlmmDirectSingleSided.ts
+++ b/examples/zapInDlmmDirectSingleSided.ts
@@ -10,6 +10,7 @@ import { estimateDlmmDirectSwap, Zap, DlmmSingleSided } from "../src";
 import Decimal from "decimal.js";
 import BN from "bn.js";
 import { createJitoTipIx, getKeypairFromSeed, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const JITO_PRIVATE_KEY = process.env.JITO_PRIVATE_KEY!;
 
@@ -30,7 +31,7 @@ async function main() {
   );
   const amountUseToAddLiquidity = new BN(100 * 10 ** 6); // 100 PUMP
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 68;
   const isInputTokenX = inputTokenMint.equals(dlmm.lbPair.tokenXMint);
@@ -51,6 +52,8 @@ async function main() {
     maxDeltaId,
     strategy: StrategyType.Spot,
     singleSided,
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
   });
 
   const result = await zap.getZapInDlmmDirectParams({

--- a/examples/zapInDlmmIndirect.ts
+++ b/examples/zapInDlmmIndirect.ts
@@ -31,7 +31,10 @@ const SWAP_SLIPPAGE_BPS = 1.5 * 100;
 
   const amountUseToAddLiquidity = new BN(0.001 * LAMPORTS_PER_SOL);
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
@@ -44,8 +47,10 @@ const SWAP_SLIPPAGE_BPS = 1.5 * 100;
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
-    jupiterApiUrl: JUPITER_API_URL,
-    jupiterApiKey: JUPITER_API_KEY,
+    config: {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    },
   });
 
   const result = await zap.getZapInDlmmIndirectParams({

--- a/examples/zapInDlmmIndirect.ts
+++ b/examples/zapInDlmmIndirect.ts
@@ -11,6 +11,7 @@ import Decimal from "decimal.js";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 import { createJitoTipIx, getKeypairFromSeed, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const JITO_PRIVATE_KEY = process.env.JITO_PRIVATE_KEY!;
 
@@ -30,7 +31,7 @@ const SWAP_SLIPPAGE_BPS = 1.5 * 100;
 
   const amountUseToAddLiquidity = new BN(0.001 * LAMPORTS_PER_SOL);
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
@@ -43,6 +44,8 @@ const SWAP_SLIPPAGE_BPS = 1.5 * 100;
     minDeltaId: -binDelta,
     maxDeltaId: binDelta,
     strategy: StrategyType.Spot,
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
   });
 
   const result = await zap.getZapInDlmmIndirectParams({

--- a/examples/zapInDlmmIndirectSingleSided.ts
+++ b/examples/zapInDlmmIndirectSingleSided.ts
@@ -11,6 +11,7 @@ import Decimal from "decimal.js";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 import { createJitoTipIx, getKeypairFromSeed, sendJitoBundle } from "./helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 const JITO_PRIVATE_KEY = process.env.JITO_PRIVATE_KEY!;
 
@@ -30,7 +31,7 @@ async function main() {
 
   const amountUseToAddLiquidity = new BN(0.001 * LAMPORTS_PER_SOL);
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
   const singleSided = DlmmSingleSided.X; // MET
@@ -51,6 +52,8 @@ async function main() {
     maxDeltaId,
     strategy: StrategyType.Spot,
     singleSided,
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
   });
 
   const result = await zap.getZapInDlmmIndirectParams({

--- a/examples/zapInDlmmIndirectSingleSided.ts
+++ b/examples/zapInDlmmIndirectSingleSided.ts
@@ -31,7 +31,10 @@ async function main() {
 
   const amountUseToAddLiquidity = new BN(0.001 * LAMPORTS_PER_SOL);
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
   const dlmm = await DLMM.create(connection, dlmmPool);
   const binDelta = 34;
   const singleSided = DlmmSingleSided.X; // MET
@@ -52,8 +55,10 @@ async function main() {
     maxDeltaId,
     strategy: StrategyType.Spot,
     singleSided,
-    jupiterApiUrl: JUPITER_API_URL,
-    jupiterApiKey: JUPITER_API_KEY,
+    config: {
+      jupiterApiUrl: JUPITER_API_URL,
+      jupiterApiKey: JUPITER_API_KEY,
+    },
   });
 
   const result = await zap.getZapInDlmmIndirectParams({

--- a/examples/zapOutThroughDammV2.ts
+++ b/examples/zapOutThroughDammV2.ts
@@ -14,6 +14,7 @@ import {
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 import { getTokenProgramFromMint, wrapSOLInstruction } from "../src/helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com");
@@ -24,7 +25,7 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"

--- a/examples/zapOutThroughDammV2.ts
+++ b/examples/zapOutThroughDammV2.ts
@@ -25,7 +25,10 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"

--- a/examples/zapOutThroughDlmm.ts
+++ b/examples/zapOutThroughDlmm.ts
@@ -14,6 +14,7 @@ import {
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 import { getTokenProgramFromMint, wrapSOLInstruction } from "../src/helpers";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com");
@@ -24,7 +25,7 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"

--- a/examples/zapOutThroughDlmm.ts
+++ b/examples/zapOutThroughDlmm.ts
@@ -25,7 +25,10 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"

--- a/examples/zapOutThroughJupiter.ts
+++ b/examples/zapOutThroughJupiter.ts
@@ -19,6 +19,7 @@ import {
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
+import { JUPITER_API_KEY, JUPITER_API_URL } from "./constants";
 
 async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com");
@@ -29,7 +30,7 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection);
+  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
@@ -51,13 +52,16 @@ async function main() {
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      JUPITER_API_URL,
+      JUPITER_API_KEY
     );
 
     console.log("Getting swap instruction from Jupiter API...");
     const swapInstructionResponse = await getJupiterSwapInstruction(
       wallet.publicKey,
-      quoteResponse
+      quoteResponse,
+      JUPITER_API_URL,
+      JUPITER_API_KEY
     );
     // console.log(swapInstructionResponse);
     const { blockhash } = await connection.getLatestBlockhash();

--- a/examples/zapOutThroughJupiter.ts
+++ b/examples/zapOutThroughJupiter.ts
@@ -30,7 +30,10 @@ async function main() {
   const anotherWallet = Keypair.fromSecretKey(Uint8Array.from([]));
   console.log(`Using another wallet: ${anotherWallet.publicKey.toString()}`);
 
-  const zap = new Zap(connection, JUPITER_API_URL, JUPITER_API_KEY);
+  const zap = new Zap(connection, {
+    jupiterApiUrl: JUPITER_API_URL,
+    jupiterApiKey: JUPITER_API_KEY,
+  });
 
   const inputMint = new PublicKey(
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
@@ -52,16 +55,20 @@ async function main() {
       false,
       true,
       true,
-      JUPITER_API_URL,
-      JUPITER_API_KEY
+      {
+        jupiterApiUrl: JUPITER_API_URL,
+        jupiterApiKey: JUPITER_API_KEY,
+      }
     );
 
     console.log("Getting swap instruction from Jupiter API...");
     const swapInstructionResponse = await getJupiterSwapInstruction(
       wallet.publicKey,
       quoteResponse,
-      JUPITER_API_URL,
-      JUPITER_API_KEY
+      {
+        jupiterApiUrl: JUPITER_API_URL,
+        jupiterApiKey: JUPITER_API_KEY,
+      }
     );
     // console.log(swapInstructionResponse);
     const { blockhash } = await connection.getLatestBlockhash();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/zap-sdk",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A Typescript SDK for interacting with the Zap program on Meteora.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,3 +53,5 @@ export const AMOUNT_IN_DAMM_V2_OFFSET = 8;
 export const DAMM_V2_SWAP_DISCRIMINATOR = [
   248, 198, 158, 145, 225, 117, 135, 200,
 ];
+
+export const DEFAULT_JUPITER_API_URL = "https://api.jup.ag";

--- a/src/helpers/jupiter.ts
+++ b/src/helpers/jupiter.ts
@@ -19,8 +19,8 @@ export async function getJupiterQuote(
   dynamicSlippage: boolean = false,
   onlyDirectRoutes: boolean,
   restrictIntermediateTokens: boolean,
-  apiUrl: string = "https://lite-api.jup.ag",
-  apiKey?: string
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
 ): Promise<JupiterQuoteResponse | null> {
   const params = new URLSearchParams({
     inputMint: inputMint.toString(),
@@ -33,7 +33,7 @@ export async function getJupiterQuote(
     dynamicSlippage: dynamicSlippage.toString(),
   });
 
-  const url = `${apiUrl}/swap/v1/quote?${params.toString()}`;
+  const url = `${jupiterApiUrl}/swap/v1/quote?${params.toString()}`;
 
   let response = null;
   try {
@@ -41,7 +41,7 @@ export async function getJupiterQuote(
       method: "GET",
       headers: {
         Accept: "application/json",
-        ...(apiKey ? { "x-api-key": apiKey } : {}),
+        ...(jupiterApiKey ? { "x-api-key": jupiterApiKey } : {}),
       },
     });
 
@@ -62,10 +62,10 @@ export async function getJupiterQuote(
 export async function getJupiterSwapInstruction(
   userPublicKey: PublicKey,
   quoteResponse: any,
-  apiUrl: string = "https://lite-api.jup.ag",
-  apiKey?: string
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
 ): Promise<JupiterSwapInstructionResponse> {
-  const url = `${apiUrl}/swap/v1/swap-instructions`;
+  const url = `${jupiterApiUrl}/swap/v1/swap-instructions`;
 
   const requestBody = {
     userPublicKey: userPublicKey.toString(),
@@ -79,7 +79,7 @@ export async function getJupiterSwapInstruction(
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
-        ...(apiKey ? { "x-api-key": apiKey } : {}),
+        ...(jupiterApiKey ? { "x-api-key": jupiterApiKey } : {}),
       },
       body: JSON.stringify(requestBody),
     });
@@ -106,7 +106,9 @@ export async function buildJupiterSwapTransaction(
   amount: BN,
   maxAccounts: number,
   slippageBps: number,
-  jupiterQuoteResponse?: JupiterQuoteResponse
+  jupiterQuoteResponse?: JupiterQuoteResponse,
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
 ): Promise<{
   transaction: Transaction;
   quoteResponse: JupiterQuoteResponse;
@@ -122,7 +124,8 @@ export async function buildJupiterSwapTransaction(
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     ));
 
   if (!quoteResponse) {
@@ -133,7 +136,9 @@ export async function buildJupiterSwapTransaction(
 
   const swapInstructionResponse = await getJupiterSwapInstruction(
     user,
-    quoteResponse
+    quoteResponse,
+    jupiterApiUrl,
+    jupiterApiKey
   );
   const instruction = new TransactionInstruction({
     keys: swapInstructionResponse.swapInstruction.accounts.map((item) => {

--- a/src/helpers/zapin/dammV2.ts
+++ b/src/helpers/zapin/dammV2.ts
@@ -91,7 +91,9 @@ export async function getJupAndDammV2Quotes(
   tokenBDecimal: number,
   dammV2SlippageBps: number,
   jupSlippageBps: number,
-  maxAccounts: number
+  maxAccounts: number,
+  jupiterApiUrl: string = "https://api.jup.ag",
+  jupiterApiKey: string = ""
 ): Promise<{
   dammV2Quote: {
     swapInAmount: BN;
@@ -147,7 +149,8 @@ export async function getJupAndDammV2Quotes(
     false,
     true,
     true,
-    "https://lite-api.jup.ag"
+    jupiterApiUrl,
+    jupiterApiKey
   );
   return {
     dammV2Quote,

--- a/src/helpers/zapin/dammV2.ts
+++ b/src/helpers/zapin/dammV2.ts
@@ -4,7 +4,7 @@ import { Connection, PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import Decimal from "decimal.js";
 import { getJupiterQuote } from "../jupiter";
-import { JupiterQuoteResponse } from "../../types";
+import { JupiterQuoteResponse, ZapConfig } from "../../types";
 import {
   convertUiAmountToLamports,
   convertLamportsToUiAmount,
@@ -92,8 +92,7 @@ export async function getJupAndDammV2Quotes(
   dammV2SlippageBps: number,
   jupSlippageBps: number,
   maxAccounts: number,
-  jupiterApiUrl: string = "https://api.jup.ag",
-  jupiterApiKey: string = ""
+  config: ZapConfig = {}
 ): Promise<{
   dammV2Quote: {
     swapInAmount: BN;
@@ -149,8 +148,7 @@ export async function getJupAndDammV2Quotes(
     false,
     true,
     true,
-    jupiterApiUrl,
-    jupiterApiKey
+    config
   );
   return {
     dammV2Quote,

--- a/src/helpers/zapin/dlmmSwapCalculations.ts
+++ b/src/helpers/zapin/dlmmSwapCalculations.ts
@@ -46,6 +46,8 @@ interface EstimateDlmmDirectSwapCoreParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
+  jupiterApiUrl: string;
+  jupiterApiKey: string;
 }
 
 function getBinAmountDistribution(
@@ -134,7 +136,9 @@ async function getBestSwapQuoteJupiterDlmm(
   inAmount: BN,
   swapSlippageBps: number,
   swapForY: boolean,
-  binArrays: BinArrayAccount[]
+  binArrays: BinArrayAccount[],
+  jupiterApiUrl: string,
+  jupiterApiKey: string
 ): Promise<SwapQuoteResult | null> {
   let dlmmQuoteResult = null;
   try {
@@ -157,7 +161,8 @@ async function getBestSwapQuoteJupiterDlmm(
     false,
     true,
     true,
-    "https://lite-api.jup.ag"
+    jupiterApiUrl,
+    jupiterApiKey
   );
 
   // normalizing the quote interface
@@ -350,6 +355,8 @@ function binarySearchRefineDirectSwapAmount(
  * @param params.maxDeltaId - Maximum bin delta from active bin
  * @param params.strategy - Strategy type for the position
  * @param params.singleSided - Optional single-sided deposit mode (X or Y only) - default is non-single-sided
+ * @param params.jupiterApiUrl - Optional - The URL of the Jupiter API (default is https://api.jup.ag)
+ * @param params.jupiterApiKey - Optional - The API key for the Jupiter API (default is empty string)
  * @returns IndirectSwapEstimate with swap details and post-swap token amounts
  * @throws if inputTokenMint matches any token in the DLMM pool
  * @throws if failed to get Jupiter swap quote
@@ -364,6 +371,8 @@ export async function estimateDlmmIndirectSwap({
   maxDeltaId,
   strategy,
   singleSided,
+  jupiterApiUrl = "https://api.jup.ag",
+  jupiterApiKey = "",
 }: EstimateDlmmIndirectSwapParams): Promise<DlmmIndirectSwapEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
   const activeBin = await dlmm.getActiveBin();
@@ -399,7 +408,8 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     );
 
     if (!quote) {
@@ -434,7 +444,8 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     ),
     getJupiterQuote(
       inputTokenMint,
@@ -445,7 +456,8 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     ),
   ]);
 
@@ -576,7 +588,8 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     ),
     getJupiterQuote(
       inputTokenMint,
@@ -587,7 +600,8 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      "https://lite-api.jup.ag"
+      jupiterApiUrl,
+      jupiterApiKey
     ),
   ]);
 
@@ -645,6 +659,8 @@ async function estimateDlmmDirectSwapCore({
   maxDeltaId,
   strategy,
   singleSided,
+  jupiterApiUrl,
+  jupiterApiKey,
 }: EstimateDlmmDirectSwapCoreParams): Promise<DlmmDirectEstimateResult> {
   if (singleSided !== undefined) {
     // swap all input to target token
@@ -662,7 +678,9 @@ async function estimateDlmmDirectSwapCore({
         tokenYAmount,
         swapSlippageBps,
         swapForY,
-        binArrayForSwap
+        binArrayForSwap,
+        jupiterApiUrl,
+        jupiterApiKey
       );
 
       if (!quote) {
@@ -692,7 +710,9 @@ async function estimateDlmmDirectSwapCore({
         tokenXAmount,
         swapSlippageBps,
         swapForY,
-        binArrayForSwap
+        binArrayForSwap,
+        jupiterApiUrl,
+        jupiterApiKey
       );
 
       if (!quote) {
@@ -808,7 +828,9 @@ async function estimateDlmmDirectSwapCore({
     initialSwapAmount,
     swapSlippageBps,
     swapForY,
-    binArrayForSwap
+    binArrayForSwap,
+    jupiterApiUrl,
+    jupiterApiKey
   );
 
   if (!initialQuote) {
@@ -883,7 +905,9 @@ async function estimateDlmmDirectSwapCore({
     refinedAmount,
     swapSlippageBps,
     swapForY,
-    binArrayForSwap
+    binArrayForSwap,
+    jupiterApiUrl,
+    jupiterApiKey
   );
 
   if (!finalQuote) {
@@ -946,6 +970,8 @@ export async function estimateDlmmDirectSwap({
   maxDeltaId,
   strategy,
   singleSided,
+  jupiterApiUrl = "https://api.jup.ag",
+  jupiterApiKey = "",
 }: EstimateDlmmDirectSwapParams): Promise<DlmmDirectSwapEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
 
@@ -968,6 +994,8 @@ export async function estimateDlmmDirectSwap({
     maxDeltaId,
     strategy,
     singleSided,
+    jupiterApiUrl,
+    jupiterApiKey,
   });
 
   return {
@@ -999,6 +1027,8 @@ export async function estimateDlmmDirectSwap({
  * @param params.minDeltaId - Minimum bin delta from active bin
  * @param params.maxDeltaId - Maximum bin delta from active bin
  * @param params.strategy - Strategy type for the position
+ * @param params.jupiterApiUrl - Optional - The URL of the Jupiter API (default is https://api.jup.ag)
+ * @param params.jupiterApiKey - Optional - The API key for the Jupiter API (default is empty string)
  * @returns DirectSwapEstimate with swap details and post-swap token amounts
  * @throws if failed to get both Jupiter and DLMM swap quotes
  */
@@ -1010,6 +1040,8 @@ export async function estimateDlmmRebalanceSwap({
   minDeltaId,
   maxDeltaId,
   strategy,
+  jupiterApiUrl = "https://api.jup.ag",
+  jupiterApiKey = "",
 }: EstimateDlmmRebalanceSwapParams): Promise<DlmmDirectRebalanceEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
   const userPosition = await dlmm.getPosition(position);
@@ -1023,6 +1055,8 @@ export async function estimateDlmmRebalanceSwap({
     maxDeltaId,
     strategy,
     singleSided: undefined, // rebalance does not use single-sided deposits
+    jupiterApiUrl,
+    jupiterApiKey,
   });
 
   return {

--- a/src/helpers/zapin/dlmmSwapCalculations.ts
+++ b/src/helpers/zapin/dlmmSwapCalculations.ts
@@ -17,6 +17,7 @@ import {
   DlmmDirectRebalanceEstimate,
   DlmmDirectSwapEstimate,
   DlmmDirectEstimateResult,
+  ZapConfig,
 } from "../../types";
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
@@ -46,8 +47,7 @@ interface EstimateDlmmDirectSwapCoreParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
-  jupiterApiUrl: string;
-  jupiterApiKey: string;
+  config?: ZapConfig;
 }
 
 function getBinAmountDistribution(
@@ -137,8 +137,7 @@ async function getBestSwapQuoteJupiterDlmm(
   swapSlippageBps: number,
   swapForY: boolean,
   binArrays: BinArrayAccount[],
-  jupiterApiUrl: string,
-  jupiterApiKey: string
+  config: ZapConfig = {}
 ): Promise<SwapQuoteResult | null> {
   let dlmmQuoteResult = null;
   try {
@@ -161,8 +160,7 @@ async function getBestSwapQuoteJupiterDlmm(
     false,
     true,
     true,
-    jupiterApiUrl,
-    jupiterApiKey
+    config
   );
 
   // normalizing the quote interface
@@ -355,8 +353,7 @@ function binarySearchRefineDirectSwapAmount(
  * @param params.maxDeltaId - Maximum bin delta from active bin
  * @param params.strategy - Strategy type for the position
  * @param params.singleSided - Optional single-sided deposit mode (X or Y only) - default is non-single-sided
- * @param params.jupiterApiUrl - Optional - The URL of the Jupiter API (default is https://api.jup.ag)
- * @param params.jupiterApiKey - Optional - The API key for the Jupiter API (default is empty string)
+ * @param params.config - Optional configuration for Jupiter API URL (default: https://api.jup.ag) and API key (default: empty string)
  * @returns IndirectSwapEstimate with swap details and post-swap token amounts
  * @throws if inputTokenMint matches any token in the DLMM pool
  * @throws if failed to get Jupiter swap quote
@@ -371,8 +368,7 @@ export async function estimateDlmmIndirectSwap({
   maxDeltaId,
   strategy,
   singleSided,
-  jupiterApiUrl = "https://api.jup.ag",
-  jupiterApiKey = "",
+  config = {},
 }: EstimateDlmmIndirectSwapParams): Promise<DlmmIndirectSwapEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
   const activeBin = await dlmm.getActiveBin();
@@ -408,8 +404,7 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      jupiterApiUrl,
-      jupiterApiKey
+      config
     );
 
     if (!quote) {
@@ -444,8 +439,7 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      jupiterApiUrl,
-      jupiterApiKey
+      config
     ),
     getJupiterQuote(
       inputTokenMint,
@@ -456,8 +450,7 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      jupiterApiUrl,
-      jupiterApiKey
+      config
     ),
   ]);
 
@@ -588,8 +581,7 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      jupiterApiUrl,
-      jupiterApiKey
+      config
     ),
     getJupiterQuote(
       inputTokenMint,
@@ -600,8 +592,7 @@ export async function estimateDlmmIndirectSwap({
       false,
       true,
       true,
-      jupiterApiUrl,
-      jupiterApiKey
+      config
     ),
   ]);
 
@@ -659,8 +650,7 @@ async function estimateDlmmDirectSwapCore({
   maxDeltaId,
   strategy,
   singleSided,
-  jupiterApiUrl,
-  jupiterApiKey,
+  config = {},
 }: EstimateDlmmDirectSwapCoreParams): Promise<DlmmDirectEstimateResult> {
   if (singleSided !== undefined) {
     // swap all input to target token
@@ -679,8 +669,7 @@ async function estimateDlmmDirectSwapCore({
         swapSlippageBps,
         swapForY,
         binArrayForSwap,
-        jupiterApiUrl,
-        jupiterApiKey
+        config
       );
 
       if (!quote) {
@@ -711,8 +700,7 @@ async function estimateDlmmDirectSwapCore({
         swapSlippageBps,
         swapForY,
         binArrayForSwap,
-        jupiterApiUrl,
-        jupiterApiKey
+        config
       );
 
       if (!quote) {
@@ -829,8 +817,7 @@ async function estimateDlmmDirectSwapCore({
     swapSlippageBps,
     swapForY,
     binArrayForSwap,
-    jupiterApiUrl,
-    jupiterApiKey
+    config
   );
 
   if (!initialQuote) {
@@ -906,8 +893,7 @@ async function estimateDlmmDirectSwapCore({
     swapSlippageBps,
     swapForY,
     binArrayForSwap,
-    jupiterApiUrl,
-    jupiterApiKey
+    config
   );
 
   if (!finalQuote) {
@@ -957,6 +943,7 @@ async function estimateDlmmDirectSwapCore({
  * @param params.maxDeltaId - Maximum bin delta from active bin
  * @param params.strategy - Strategy type for the position
  * @param params.singleSided - Optional single-sided deposit mode (X or Y only) - default is non-single-sided
+ * @param params.config - Optional configuration for Jupiter API URL (default: https://api.jup.ag) and API key (default: empty string)
  * @returns DirectSwapEstimate with swap details and post-swap token amounts
  * @throws if failed to get both Jupiter and DLMM swap quotes
  */
@@ -970,8 +957,7 @@ export async function estimateDlmmDirectSwap({
   maxDeltaId,
   strategy,
   singleSided,
-  jupiterApiUrl = "https://api.jup.ag",
-  jupiterApiKey = "",
+  config = {},
 }: EstimateDlmmDirectSwapParams): Promise<DlmmDirectSwapEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
 
@@ -994,8 +980,7 @@ export async function estimateDlmmDirectSwap({
     maxDeltaId,
     strategy,
     singleSided,
-    jupiterApiUrl,
-    jupiterApiKey,
+    config,
   });
 
   return {
@@ -1027,8 +1012,7 @@ export async function estimateDlmmDirectSwap({
  * @param params.minDeltaId - Minimum bin delta from active bin
  * @param params.maxDeltaId - Maximum bin delta from active bin
  * @param params.strategy - Strategy type for the position
- * @param params.jupiterApiUrl - Optional - The URL of the Jupiter API (default is https://api.jup.ag)
- * @param params.jupiterApiKey - Optional - The API key for the Jupiter API (default is empty string)
+ * @param params.config - Optional configuration for Jupiter API URL (default: https://api.jup.ag) and API key (default: empty string)
  * @returns DirectSwapEstimate with swap details and post-swap token amounts
  * @throws if failed to get both Jupiter and DLMM swap quotes
  */
@@ -1040,8 +1024,7 @@ export async function estimateDlmmRebalanceSwap({
   minDeltaId,
   maxDeltaId,
   strategy,
-  jupiterApiUrl = "https://api.jup.ag",
-  jupiterApiKey = "",
+  config = {},
 }: EstimateDlmmRebalanceSwapParams): Promise<DlmmDirectRebalanceEstimate> {
   const dlmm = await DLMM.create(connection, lbPair);
   const userPosition = await dlmm.getPosition(position);
@@ -1055,8 +1038,7 @@ export async function estimateDlmmRebalanceSwap({
     maxDeltaId,
     strategy,
     singleSided: undefined, // rebalance does not use single-sided deposits
-    jupiterApiUrl,
-    jupiterApiKey,
+    config,
   });
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,11 @@ import {
 
 export type ZapProgram = Program<Zap>;
 
+export type ZapConfig = {
+  jupiterApiUrl?: string;
+  jupiterApiKey?: string;
+};
+
 ///// ZAPOUT TYPES /////
 export type ZapOutParameters = IdlTypes<Zap>["zapOutParameters"];
 
@@ -270,8 +275,7 @@ export interface EstimateDlmmDirectSwapParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
-  jupiterApiUrl?: string;
-  jupiterApiKey?: string;
+  config?: ZapConfig;
 }
 
 export interface DlmmDirectSwapEstimateContext {
@@ -307,8 +311,7 @@ export interface EstimateDlmmRebalanceSwapParams {
   maxDeltaId: number;
   swapSlippageBps: number;
   strategy: StrategyType;
-  jupiterApiUrl?: string;
-  jupiterApiKey?: string;
+  config?: ZapConfig;
 }
 
 export interface DlmmDirectRebalanceEstimateContext {
@@ -336,8 +339,7 @@ export interface EstimateDlmmIndirectSwapParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
-  jupiterApiUrl?: string;
-  jupiterApiKey?: string;
+  config?: ZapConfig;
 }
 
 export interface DlmmIndirectSwapEstimateResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,6 +270,8 @@ export interface EstimateDlmmDirectSwapParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
+  jupiterApiUrl?: string;
+  jupiterApiKey?: string;
 }
 
 export interface DlmmDirectSwapEstimateContext {
@@ -305,6 +307,8 @@ export interface EstimateDlmmRebalanceSwapParams {
   maxDeltaId: number;
   swapSlippageBps: number;
   strategy: StrategyType;
+  jupiterApiUrl?: string;
+  jupiterApiKey?: string;
 }
 
 export interface DlmmDirectRebalanceEstimateContext {
@@ -332,6 +336,8 @@ export interface EstimateDlmmIndirectSwapParams {
   maxDeltaId: number;
   strategy: StrategyType;
   singleSided?: DlmmSingleSided;
+  jupiterApiUrl?: string;
+  jupiterApiKey?: string;
 }
 
 export interface DlmmIndirectSwapEstimateResult {

--- a/src/zap.ts
+++ b/src/zap.ts
@@ -34,6 +34,7 @@ import {
   DlmmDirectSwapQuoteRoute,
   DlmmSingleSided,
   ZapInDammV2PoolSwapRoute,
+  ZapConfig,
 } from "./types";
 
 import {
@@ -61,6 +62,7 @@ import {
   AMOUNT_IN_DLMM_OFFSET,
   AMOUNT_IN_JUP_V6_REVERSE_OFFSET,
   DAMM_V2_PROGRAM_ID,
+  DEFAULT_JUPITER_API_URL,
   DLMM_PROGRAM_ID,
   JUP_V6_PROGRAM_ID,
   MEMO_PROGRAM_ID,
@@ -104,15 +106,15 @@ export class Zap {
   private jupiterApiUrl: string;
   private jupiterApiKey: string;
   public zapProgram: ZapProgram;
-  constructor(
-    connection: Connection,
-    jupiterApiUrl: string = "https://api.jup.ag",
-    jupiterApiKey: string = ""
-  ) {
+  /**
+   * @param connection - The connection to the Solana cluster
+   * @param config - Optional configuration for Jupiter API URL (default: https://api.jup.ag) and API key (default: empty string)
+   */
+  constructor(connection: Connection, config: ZapConfig = {}) {
     this.connection = connection;
     this.zapProgram = new Program(ZapIDL as ZapTypes, { connection });
-    this.jupiterApiUrl = jupiterApiUrl;
-    this.jupiterApiKey = jupiterApiKey;
+    this.jupiterApiUrl = config.jupiterApiUrl || DEFAULT_JUPITER_API_URL;
+    this.jupiterApiKey = config.jupiterApiKey || "";
   }
 
   /////// PRIVATE FUNDTIONS //////
@@ -588,8 +590,10 @@ export class Zap {
         maxAccounts,
         slippageBps,
         undefined,
-        this.jupiterApiUrl,
-        this.jupiterApiKey
+        {
+          jupiterApiUrl: this.jupiterApiUrl,
+          jupiterApiKey: this.jupiterApiKey,
+        }
       );
       swapTransactions = [result.transaction];
       maxTransferAmount = getExtendMaxAmountTransfer(
@@ -788,8 +792,10 @@ export class Zap {
           maxAccounts,
           slippageBps,
           undefined,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
 
       return {
@@ -835,8 +841,10 @@ export class Zap {
           maxAccounts,
           slippageBps,
           undefined,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
 
       return {
@@ -909,8 +917,10 @@ export class Zap {
           maxAccounts,
           slippageBps,
           undefined,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
 
       const { transaction: swapToBTransaction, quoteResponse: swapToBQuote } =
@@ -922,8 +932,10 @@ export class Zap {
           maxAccounts,
           slippageBps,
           undefined,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
       return {
         user,
@@ -1242,8 +1254,10 @@ export class Zap {
           maxAccounts,
           swapSlippageBps,
           swapQuote.originalQuote,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
         swapTransactions.push(swapTx);
       } else {
@@ -1446,8 +1460,10 @@ export class Zap {
           maxAccounts,
           swapSlippageBps,
           indirectSwapEstimate.swapToX,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
       swapTransactions.push(swapToXTransaction);
     }
@@ -1465,8 +1481,10 @@ export class Zap {
           maxAccounts,
           swapSlippageBps,
           indirectSwapEstimate.swapToY,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
       swapTransactions.push(swapToYTransaction);
     }
@@ -1932,8 +1950,10 @@ export class Zap {
           maxAccounts,
           swapSlippageBps,
           swapQuote.originalQuote,
-          this.jupiterApiUrl,
-          this.jupiterApiKey
+          {
+            jupiterApiUrl: this.jupiterApiUrl,
+            jupiterApiKey: this.jupiterApiKey,
+          }
         );
         swapTransaction = swapTx;
       } else {

--- a/src/zap.ts
+++ b/src/zap.ts
@@ -101,10 +101,18 @@ import {
 
 export class Zap {
   private connection: Connection;
+  private jupiterApiUrl: string;
+  private jupiterApiKey: string;
   public zapProgram: ZapProgram;
-  constructor(connection: Connection) {
+  constructor(
+    connection: Connection,
+    jupiterApiUrl: string = "https://api.jup.ag",
+    jupiterApiKey: string = ""
+  ) {
     this.connection = connection;
     this.zapProgram = new Program(ZapIDL as ZapTypes, { connection });
+    this.jupiterApiUrl = jupiterApiUrl;
+    this.jupiterApiKey = jupiterApiKey;
   }
 
   /////// PRIVATE FUNDTIONS //////
@@ -578,7 +586,10 @@ export class Zap {
         tokenAMint.equals(inputTokenMint) ? tokenBMint : tokenAMint,
         swapInAmount,
         maxAccounts,
-        slippageBps
+        slippageBps,
+        undefined,
+        this.jupiterApiUrl,
+        this.jupiterApiKey
       );
       swapTransactions = [result.transaction];
       maxTransferAmount = getExtendMaxAmountTransfer(
@@ -775,7 +786,10 @@ export class Zap {
           tokenAMint,
           amountIn,
           maxAccounts,
-          slippageBps
+          slippageBps,
+          undefined,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
 
       return {
@@ -819,7 +833,10 @@ export class Zap {
           tokenBMint,
           amountIn,
           maxAccounts,
-          slippageBps
+          slippageBps,
+          undefined,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
 
       return {
@@ -890,7 +907,10 @@ export class Zap {
           tokenAMint,
           swapAmountToA,
           maxAccounts,
-          slippageBps
+          slippageBps,
+          undefined,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
 
       const { transaction: swapToBTransaction, quoteResponse: swapToBQuote } =
@@ -900,7 +920,10 @@ export class Zap {
           tokenBMint,
           swapAmountToB,
           maxAccounts,
-          slippageBps
+          slippageBps,
+          undefined,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
       return {
         user,
@@ -1218,7 +1241,9 @@ export class Zap {
           directSwapEstimate.swapAmount,
           maxAccounts,
           swapSlippageBps,
-          swapQuote.originalQuote
+          swapQuote.originalQuote,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
         swapTransactions.push(swapTx);
       } else {
@@ -1420,7 +1445,9 @@ export class Zap {
           swapAmountToXInLamports,
           maxAccounts,
           swapSlippageBps,
-          indirectSwapEstimate.swapToX
+          indirectSwapEstimate.swapToX,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
       swapTransactions.push(swapToXTransaction);
     }
@@ -1437,7 +1464,9 @@ export class Zap {
           swapAmountToYInLamports,
           maxAccounts,
           swapSlippageBps,
-          indirectSwapEstimate.swapToY
+          indirectSwapEstimate.swapToY,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
       swapTransactions.push(swapToYTransaction);
     }

--- a/src/zap.ts
+++ b/src/zap.ts
@@ -1931,7 +1931,9 @@ export class Zap {
           directSwapEstimate.swapAmount,
           maxAccounts,
           swapSlippageBps,
-          swapQuote.originalQuote
+          swapQuote.originalQuote,
+          this.jupiterApiUrl,
+          this.jupiterApiKey
         );
         swapTransaction = swapTx;
       } else {


### PR DESCRIPTION
## Changes (same as in changelog)

### Added
- Jupiter API Setup section in README with instructions for obtaining API keys and configuring the SDK

### Changed

- Replace `lite-api.jup.ag` with `api.jup.ag` as the default Jupiter API endpoint
- Add optional `jupiterApiUrl` and `jupiterApiKey` parameters to `Zap` class constructor and all Jupiter-related helper functions (`getJupiterQuote`, `getJupiterSwapInstruction`, `buildJupiterSwapTransaction`, `getJupAndDammV2Quotes`, `estimateDlmmIndirectSwap`, `estimateDlmmDirectSwap`, `estimateDlmmRebalanceSwap`) for explicit API configuration